### PR TITLE
Keep checker pane open when all errors are gone

### DIFF
--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -52,10 +52,6 @@ export default class Checker extends React.Component {
     return "Checker"
   }
 
-  componentWillUnmount() {
-    clearTimeout(this._closeTimout)
-  }
-
   setConfig(config) {
     this.setState({ config })
   }
@@ -118,9 +114,6 @@ export default class Checker extends React.Component {
               done()
             }
           })
-          if (errors.length === 0) {
-            this._closeTimout = setTimeout(() => this.handleClose(), 3000)
-          }
         }
       )
     }


### PR DESCRIPTION
closes CORE-1677

Test Plan:
  - yarn start
  - When the demo opens up, fix all the errors
  - When all the errors are fixed, the checker
    should stay open.