### PR TITLE
Make previous button read as 'previous'

### DIFF
--- a/src/components/__tests__/__snapshots__/checker.js.snap
+++ b/src/components/__tests__/__snapshots__/checker.js.snap
@@ -316,6 +316,7 @@ exports[`render matches snapshot with errors 1`] = `
                   textAlign="inherit"
                 >
                   <Button
+                    aria-label="Previous"
                     as="button"
                     buttonRef={[Function]}
                     fluidWidth={false}

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -384,6 +384,7 @@ export default class Checker extends React.Component {
                           <Button
                             onClick={() => this.prevError()}
                             margin="0 small 0 0"
+                            aria-label="Previous"
                           >
                             {formatMessage("Prev")}
                           </Button>


### PR DESCRIPTION
closes CORE-1702

Test Plan:
  - With a screenreader open the a11y checker
  - Navigate to the previous button
  - It should read as 'previous' rather than 'prev'