### PR TITLE
Clear up canvas errors when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "enzyme-to-json": "^3.0.1",
     "format-message-cli": "^6",
     "jest": "^23",
+    "jest-canvas-mock": "^1.1.0",
     "moxios": "^0.4.0",
     "prettier": "^1.7.3",
     "quiz-presets": "^5",
@@ -72,7 +73,8 @@
   },
   "jest": {
     "setupFiles": [
-      "./jest-setup.js"
+      "./jest-setup.js",
+      "jest-canvas-mock"
     ],
     "snapshotSerializers": [
       "<rootDir>/node_modules/enzyme-to-json/serializer"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6890,6 +6890,10 @@ items@2.x.x:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/items/-/items-2.1.1.tgz#8bd16d9c83b19529de5aea321acaada78364a198"
 
+jest-canvas-mock@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-1.1.0.tgz#f6ed0998b6be3ae2b7e095d7173441ae62cc831e"
+
 jest-changed-files@^23.4.2:
   version "23.4.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"


### PR DESCRIPTION
Test Plan:
  - npm test
  - No 'canvas' errors should show