### PR TITLE
Highlight infractions rather than select

### DIFF
--- a/cypress/integration/indicator_spec.js
+++ b/cypress/integration/indicator_spec.js
@@ -1,0 +1,40 @@
+describe("Indicator", () => {
+  beforeEach(() => {
+    cy.visit("http://127.0.0.1:8080")
+    cy.get("[aria-label='Check Accessibility']").click()
+  })
+
+  it("should indicate errors when they are active in the checker", () => {
+    cy.get(".a11y-checker-selection-indicator").should("be.visible")
+  })
+
+  it("should not show the indicator when scrolling down out of the iframe", () => {
+    cy.get(".a11y-checker-selection-indicator").should("be.visible")
+    cy.get("iframe").then($iframe => {
+      const $body = $iframe.contents().find("body")
+      $body
+        .find("p")
+        .last()[0]
+        .scrollIntoView()
+      cy.get(".a11y-checker-selection-indicator").should("be.hidden")
+    })
+  })
+
+  it.only("should not show the indicator when scrolled up out of the iframe", () => {
+    cy.get("[aria-label='Accessibility Checker']").within(() => {
+      // Because of some async stuff the last issue isn't actually at the bottom
+      // of the page like we want here
+      cy.contains("Prev").click()
+      cy.contains("Prev").click()
+    })
+    cy.get(".a11y-checker-selection-indicator").should("be.visible")
+    cy.get("iframe").then($iframe => {
+      const $body = $iframe.contents().find("body")
+      $body
+        .find("p")
+        .first()[0]
+        .scrollIntoView()
+      cy.get(".a11y-checker-selection-indicator").should("be.hidden")
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@instructure/ui-overlays": "^5 || rc",
     "@instructure/ui-themes": "^5 || rc",
     "axios": "^0.18.0",
+    "bloody-offset": "^0.0.0",
     "format-message": "^6",
     "format-message-generate-id": "^6",
     "prevent-default": "^1.0.0",

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -149,7 +149,7 @@ export default class Checker extends React.Component {
     const errorNode = this.errorNode()
     if (errorNode) {
       this.getFormState()
-      dom.select(errorNode)
+      dom.select(this.props.editor, errorNode)
     } else {
       this.firstError()
     }

--- a/src/utils/__tests__/dom.js
+++ b/src/utils/__tests__/dom.js
@@ -15,18 +15,25 @@ test("walk calls function with each child element depth first", () => {
 })
 
 describe("select", () => {
-  let node, doc, range, sel
+  let node, doc, range, sel, editor, indicateFn
 
   beforeEach(() => {
     range = { selectNode: jest.fn() }
     sel = { addRange: jest.fn(), removeAllRanges: jest.fn() }
     doc = { createRange: () => range, getSelection: () => sel }
     node = { scrollIntoView: jest.fn(), ownerDocument: doc, childNodes: [] }
+    editor = {}
+    indicateFn = jest.fn()
   })
 
-  test("select creates a range for the doc and selects the node", () => {
-    dom.select(node)
-    expect(range.selectNode).toBeCalledWith(node)
+  test("scrolls the node into view", () => {
+    dom.select(editor, node, indicateFn)
+    expect(node.scrollIntoView).toBeCalled()
+  })
+
+  test("calls the indicator function with the editor and the node", () => {
+    dom.select(editor, node, indicateFn)
+    expect(indicateFn).toHaveBeenCalledWith(editor, node)
   })
 
   test("select does not throw if node is underfined or null", () => {

--- a/src/utils/__tests__/indicate.js
+++ b/src/utils/__tests__/indicate.js
@@ -1,0 +1,41 @@
+import indicate from "../indicate"
+
+let fakeEditor, fakeIframe, fakeElem
+
+beforeEach(() => {
+  Element.prototype.getBoundingClientRect = jest.fn(() => {
+    return {
+      width: 120,
+      height: 120,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0
+    }
+  })
+
+  fakeElem = document.createElement("div")
+  fakeIframe = document.createElement("iframe")
+  fakeEditor = {
+    getContainer: () => ({
+      querySelector: () => fakeIframe
+    })
+  }
+
+  jest
+    .spyOn(window, "requestAnimationFrame")
+    .mockImplementationOnce(cb => cb()) // This only allows it to happen twice, preventing an infinite loop
+    .mockImplementationOnce(cb => cb())
+})
+
+afterEach(() => {
+  window.requestAnimationFrame.mockRestore()
+})
+
+it("removes any existing indicators when run", () => {
+  const el = document.createElement("div")
+  el.className = "a11y-checker-selection-indicator"
+  el.id = "this_should_be_gone"
+  indicate(fakeEditor, fakeElem)
+  expect(document.getElementById("this_should_be_gone")).toBeFalsy()
+})

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,3 +1,5 @@
+import indicate from "./indicate"
+
 const ELEMENT_NODE = 1
 const WALK_BATCH_SIZE = 25
 
@@ -26,23 +28,12 @@ export function walk(node, fn, done) {
   processBatch()
 }
 
-export function select(elem) {
+export function select(editor, elem, indicateFn = indicate) {
   if (elem == null) {
     return
   }
-  const doc = elem.ownerDocument
-  const sel = doc.getSelection()
-  const range = doc.createRange()
-  if (sel.rangeCount > 0) {
-    sel.removeAllRanges()
-  }
-  if (elem.childNodes.length > 0) {
-    range.selectNodeContents(elem)
-  } else {
-    range.selectNode(elem)
-  }
-  sel.addRange(range)
   elem.scrollIntoView()
+  indicateFn(editor, elem)
 }
 
 export function prepend(parent, child) {

--- a/src/utils/indicate.js
+++ b/src/utils/indicate.js
@@ -1,0 +1,92 @@
+import offset from "bloody-offset"
+
+const MARGIN = 3
+
+export function indicatorRegion(
+  editorFrame,
+  target,
+  offsetFn = offset,
+  boundingRectOverride
+) {
+  const outerShape = offsetFn(editorFrame)
+  const b = boundingRectOverride || target.getBoundingClientRect()
+  const innerShape = {
+    top: b.top,
+    left: b.left,
+    width: b.right - b.left,
+    height: b.bottom - b.top
+  }
+
+  return {
+    width: innerShape.width,
+    height: innerShape.height,
+    left: outerShape.left + innerShape.left,
+    top: outerShape.top + innerShape.top
+  }
+}
+
+export default function indicate(editor, elem, margin = MARGIN) {
+  document
+    .querySelectorAll(".a11y-checker-selection-indicator")
+    .forEach(existingElem => {
+      existingElem.parentNode.removeChild(existingElem)
+    })
+
+  const editorFrame = editor.getContainer().querySelector("iframe")
+
+  const el = document.createElement("div")
+  el.className = "a11y-checker-selection-indicator"
+
+  const region = indicatorRegion(editorFrame, elem)
+
+  el.setAttribute(
+    "style",
+    `
+    border: 2px solid #000;
+    background-color: #008EE2;
+    position: absolute;
+    display: block;
+    borderRadius: 5px;
+    zIndex: 999999;
+    left: ${region.left - margin}px;
+    top: ${region.top - margin}px;
+    width: ${region.width + 2 * margin}px;
+    height: ${region.height + 2 * margin}px;
+    opacity: 0.5;
+  `
+  )
+
+  document.body.appendChild(el)
+
+  el.style.opacity = 0.8
+  el.style.transition = "opacity 0.4s"
+
+  const adjust = () => {
+    const boundingRect = elem.getBoundingClientRect()
+    const region = indicatorRegion(editorFrame, elem, offset, boundingRect)
+    const editorFrameOffset = offset(editorFrame)
+    el.style.left = `${region.left - margin}px`
+    el.style.top = `${region.top - margin}px`
+    el.style.display = "block"
+    if (boundingRect.top < 0) {
+      const newHeight = region.height + boundingRect.top
+      if (newHeight < 0) {
+        el.style.display = "none"
+      }
+      const newTop = region.height - newHeight
+      el.style.height = `${newHeight}px`
+      el.style.marginTop = `${newTop}px`
+    }
+    if (boundingRect.bottom > editorFrameOffset.height) {
+      const newHeight =
+        region.height + (editorFrameOffset.height - boundingRect.bottom)
+      if (newHeight < 0) {
+        el.style.display = "none"
+      }
+      el.style.height = `${newHeight}px`
+    }
+    window.requestAnimationFrame(adjust)
+  }
+
+  window.requestAnimationFrame(adjust)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2168,7 +2168,7 @@ blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
 
-bloody-offset@0.0.0:
+bloody-offset@0.0.0, bloody-offset@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/bloody-offset/-/bloody-offset-0.0.0.tgz#ce9b898ac526c0aa39f02f02567fc0993069d629"
 


### PR DESCRIPTION
This should allow VoiceOver to maintain its focus
on the next and/or previous button rather than jumping
into the editor.

closes CORE-1701
closes CORE-1703
closes CORE-1704

Test Plan:
  - Open up the a11y checker
  - Activate voiceover in safari and move through
    errors using next and previous buttons
  - Focus should stay on the button and not jump into
    the editor
  - The error should be shown highlighted in blue
  - You should be able to scroll and the blue highlight
    should stay within the editor window.