### PR TITLE
Handle existing styles with contrast updates

### DIFF
--- a/src/rules/__tests__/small-text-contrast.js
+++ b/src/rules/__tests__/small-text-contrast.js
@@ -74,12 +74,20 @@ describe("update", () => {
 
   test("sets the mce-style data attribute with the updated color", () => {
     rule.update(el, { color: "#fff" })
-    expect(el.getAttribute("data-mce-style")).toBe("color: #fff;")
+    expect(el.getAttribute("data-mce-style")).toBe("color:#fff;")
   })
 
   test("converts rgb to hex prior to setting it on the mce-style data attribute", () => {
     rule.update(el, { color: "rgb(255, 255, 255)" })
-    expect(el.getAttribute("data-mce-style")).toBe("color: #ffffff;")
+    expect(el.getAttribute("data-mce-style")).toBe("color:#ffffff;")
+  })
+
+  test("maintains other style properties set on the mce-style data attribute", () => {
+    el.setAttribute("data-mce-style", "background-color: #000000;")
+    rule.update(el, { color: "rgb(255, 255, 255)" })
+    expect(el.getAttribute("data-mce-style")).toBe(
+      "background-color:#000000;color:#ffffff;"
+    )
   })
 })
 

--- a/src/rules/img-alt-filename.js
+++ b/src/rules/img-alt-filename.js
@@ -12,7 +12,7 @@ export default {
     if (alt == null || alt === "") {
       return true
     }
-    return axios.get(elem.src).catch(e => {
+    return axios.head(elem.src).catch(e => {
       if (
         e.response &&
         (e.response.status === 301 || e.response.status === 302)

--- a/src/rules/small-text-contrast.js
+++ b/src/rules/small-text-contrast.js
@@ -1,6 +1,10 @@
 import formatMessage from "../format-message"
 import contrast from "wcag-element-contrast"
-import { onlyContainsLink } from "../utils/dom"
+import {
+  onlyContainsLink,
+  createStyleString,
+  splitStyleAttribute
+} from "../utils/dom"
 import rgbHex from "../utils/rgb-hex"
 
 export default {
@@ -36,12 +40,15 @@ export default {
 
   update: (elem, data) => {
     elem.style.color = data.color
+    const styles = splitStyleAttribute(
+      elem.getAttribute("data-mce-style") || ""
+    )
     if (data && data.color && data.color.indexOf("#") < 0) {
-      elem.setAttribute("data-mce-style", `color: #${rgbHex(data.color)};`)
+      styles.color = `#${rgbHex(data.color)}`
     } else {
-      elem.setAttribute("data-mce-style", `color: ${data.color};`)
+      styles.color = data.color
     }
-
+    elem.setAttribute("data-mce-style", createStyleString(styles))
     return elem
   },
 

--- a/src/utils/__tests__/dom.js
+++ b/src/utils/__tests__/dom.js
@@ -129,3 +129,27 @@ describe("onlyContainsLink", () => {
     expect(dom.onlyContainsLink(elem)).toBe(false)
   })
 })
+
+describe("splitStyleAttribute", () => {
+  test("creates an object with key values", () => {
+    expect(
+      dom.splitStyleAttribute("background-color: #000000; color: #ffffff;")
+    ).toMatchObject({ "background-color": "#000000", color: "#ffffff" })
+  })
+
+  test("returns an empty object when given an empty string", () => {
+    expect(dom.splitStyleAttribute("")).toEqual({})
+  })
+})
+
+describe("createStyleString", () => {
+  test("creates a style string given a style object", () => {
+    expect(
+      dom.createStyleString({ "background-color": "#000000", color: "#ffffff" })
+    ).toBe("background-color:#000000;color:#ffffff;")
+  })
+
+  test("returns an empty string when given an empty object", () => {
+    expect(dom.createStyleString({})).toBe("")
+  })
+})

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -92,3 +92,24 @@ export function onlyContainsLink(elem) {
     return false
   }
 }
+
+export function splitStyleAttribute(styleString) {
+  const split = styleString.split(";")
+  return split.reduce((styleObj, attributeValue) => {
+    const pair = attributeValue.split(":")
+    if (pair.length === 2) {
+      styleObj[pair[0].trim()] = pair[1].trim()
+    }
+    return styleObj
+  }, {})
+}
+
+export function createStyleString(styleObj) {
+  let styleString = Object.keys(styleObj)
+    .map(key => `${key}:${styleObj[key]}`)
+    .join(";")
+  if (styleString) {
+    styleString = `${styleString};`
+  }
+  return styleString
+}


### PR DESCRIPTION
closes CORE-1736

Test Plan:
  - Create black text on black background
  - Run the a11y checker and update it to white text
  - The background color should not disappear after applying