### PR TITLE
Remove indicators on close and error correction

### DIFF
--- a/cypress/integration/indicator_spec.js
+++ b/cypress/integration/indicator_spec.js
@@ -20,7 +20,7 @@ describe("Indicator", () => {
     })
   })
 
-  it.only("should not show the indicator when scrolled up out of the iframe", () => {
+  it("should not show the indicator when scrolled up out of the iframe", () => {
     cy.get("[aria-label='Accessibility Checker']").within(() => {
       // Because of some async stuff the last issue isn't actually at the bottom
       // of the page like we want here
@@ -36,5 +36,28 @@ describe("Indicator", () => {
         .scrollIntoView()
       cy.get(".a11y-checker-selection-indicator").should("be.hidden")
     })
+  })
+
+  it("should remove the indicator when the a11y checker is closed", () => {
+    cy.get(".a11y-checker-selection-indicator").should("be.visible")
+    cy.get("[aria-label='Accessibility Checker']").within(() => {
+      cy.contains("Close Accessibility Checker").click()
+    })
+    cy.get(".a11y-checker-selection-indicator").should("not.exist")
+  })
+})
+
+describe("Indicator Error Interactions", () => {
+  beforeEach(() => {
+    cy.visit("http://127.0.0.1:8080/single_error.html")
+    cy.get("[aria-label='Check Accessibility']").click()
+  })
+
+  it("should remove the indicator after clearing the last error", () => {
+    cy.get("[aria-label='Accessibility Checker']").within(() => {
+      cy.get('[type="checkbox"]').check({ force: true }) // force it because it's under a span
+      cy.contains("Apply").click()
+    })
+    cy.get(".a11y-checker-selection-indicator").should("not.exist")
   })
 })

--- a/demo/single_error.html
+++ b/demo/single_error.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html dir="ltr">
+
+<head>
+    <title>TinyMCE Accessibility Plugin Demo</title>
+    <style>
+        body {
+            width: 900px;
+            margin: 2em auto;
+            background-color: #eee;
+        }
+
+        .mce-i-a11y:before {
+            content: "\e900";
+        }
+    </style>
+</head>
+
+<body>
+    <div class="main">
+        <h1>TinyMCE Accessibility Plugin Demo</h1>
+        <div id="editor1">
+            <textarea id="textarea1">
+          
+          <h1>this is a really big heading tag. 51 chars long even. this is a really big heading tag. 51 chars long even. 12345678901234567890</h1>
+          
+        </textarea>
+        </div>
+    </div>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?rum=0"></script>
+    <script src="demo.bundle.js"></script>
+</body>
+
+</html>

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -30,6 +30,7 @@ import describe from "../utils/describe"
 import * as dom from "../utils/dom"
 import rules from "../rules"
 import formatMessage from "../format-message"
+import { clearIndicators } from "../utils/indicate"
 
 const noop = () => {}
 
@@ -146,6 +147,7 @@ export default class Checker extends React.Component {
   }
 
   selectCurrent() {
+    clearIndicators()
     const errorNode = this.errorNode()
     if (errorNode) {
       this.getFormState()
@@ -279,6 +281,7 @@ export default class Checker extends React.Component {
 
   handleClose() {
     this.onLeaveError()
+    clearIndicators()
     this.setState({ open: false })
   }
 

--- a/src/utils/__tests__/indicate.js
+++ b/src/utils/__tests__/indicate.js
@@ -1,4 +1,4 @@
-import indicate from "../indicate"
+import indicate, { clearIndicators } from "../indicate"
 
 let fakeEditor, fakeIframe, fakeElem
 
@@ -38,4 +38,14 @@ it("removes any existing indicators when run", () => {
   el.id = "this_should_be_gone"
   indicate(fakeEditor, fakeElem)
   expect(document.getElementById("this_should_be_gone")).toBeFalsy()
+})
+
+describe("clearIndicators", () => {
+  it("removes any existing indicators when called", () => {
+    const el = document.createElement("div")
+    el.className = "a11y-checker-selection-indicator"
+    el.id = "this_should_be_gone"
+    clearIndicators()
+    expect(document.getElementById("this_should_be_gone")).toBeFalsy()
+  })
 })

--- a/src/utils/indicate.js
+++ b/src/utils/indicate.js
@@ -25,12 +25,16 @@ export function indicatorRegion(
   }
 }
 
-export default function indicate(editor, elem, margin = MARGIN) {
+export function clearIndicators() {
   document
     .querySelectorAll(".a11y-checker-selection-indicator")
     .forEach(existingElem => {
       existingElem.parentNode.removeChild(existingElem)
     })
+}
+
+export default function indicate(editor, elem, margin = MARGIN) {
+  clearIndicators()
 
   const editorFrame = editor.getContainer().querySelector("iframe")
 


### PR DESCRIPTION
closes CORE-1828

Test Plan:
  - Open up the a11y checker
  - You should see an indicator
  - Close the a11y checker
  - No more indicator should be viewed
  - Open the a11y checker again
  - Resolve all the errors
  - Indicator should now also be removed