### PR TITLE
Make text node check more robust

### DIFF
--- a/src/rules/__tests__/large-text-contrast.js
+++ b/src/rules/__tests__/large-text-contrast.js
@@ -21,9 +21,11 @@ describe("test", () => {
     elem.style.backgroundColor = "#fff"
     elem.style.color = "#fff"
     elem.textContent = "disabled"
-    expect(rule.test(elem, {
-      disableContrastCheck: true
-    })).toBe(true)
+    expect(
+      rule.test(elem, {
+        disableContrastCheck: true
+      })
+    ).toBe(true)
   })
 
   test("returns true if the only content of a text node is a link", () => {

--- a/src/rules/__tests__/large-text-contrast.js
+++ b/src/rules/__tests__/large-text-contrast.js
@@ -12,7 +12,6 @@ describe("test", () => {
     elem.style.fontSize = "30px"
     elem.style.backgroundColor = "#fff"
     elem.style.color = "#fff"
-    elem.textContent = "  "
     expect(rule.test(elem)).toBe(true)
   })
 
@@ -22,7 +21,9 @@ describe("test", () => {
     elem.style.backgroundColor = "#fff"
     elem.style.color = "#fff"
     elem.textContent = "disabled"
-    expect(rule.test(elem, { disableContrastCheck: true })).toBe(true)
+    expect(rule.test(elem, {
+      disableContrastCheck: true
+    })).toBe(true)
   })
 
   test("returns true if the only content of a text node is a link", () => {

--- a/src/rules/__tests__/small-text-contrast.js
+++ b/src/rules/__tests__/small-text-contrast.js
@@ -12,7 +12,6 @@ describe("test", () => {
     elem.style.fontSize = "10px"
     elem.style.backgroundColor = "#fff"
     elem.style.color = "#fff"
-    elem.textContent = "  "
     expect(rule.test(elem)).toBe(true)
   })
 

--- a/src/rules/large-text-contrast.js
+++ b/src/rules/large-text-contrast.js
@@ -1,10 +1,7 @@
 import formatMessage from "../format-message"
 import contrast from "wcag-element-contrast"
 import smallTextContrast from "./small-text-contrast"
-import {
-  onlyContainsLink,
-  hasTextNode
-} from "../utils/dom"
+import { onlyContainsLink, hasTextNode } from "../utils/dom"
 
 export default {
   test: (elem, config = {}) => {

--- a/src/rules/large-text-contrast.js
+++ b/src/rules/large-text-contrast.js
@@ -1,12 +1,15 @@
 import formatMessage from "../format-message"
 import contrast from "wcag-element-contrast"
 import smallTextContrast from "./small-text-contrast"
-import { onlyContainsLink } from "../utils/dom"
+import {
+  onlyContainsLink,
+  hasTextNode
+} from "../utils/dom"
 
 export default {
   test: (elem, config = {}) => {
     const disabled = config.disableContrastCheck == true
-    const noText = elem.textContent.replace(/\s/g, "") === ""
+    const noText = !hasTextNode(elem)
     if (
       disabled ||
       noText ||

--- a/src/rules/small-text-contrast.js
+++ b/src/rules/small-text-contrast.js
@@ -3,14 +3,15 @@ import contrast from "wcag-element-contrast"
 import {
   onlyContainsLink,
   createStyleString,
-  splitStyleAttribute
+  splitStyleAttribute,
+  hasTextNode
 } from "../utils/dom"
 import rgbHex from "../utils/rgb-hex"
 
 export default {
   test: (elem, config = {}) => {
     const disabled = config.disableContrastCheck == true
-    const noText = elem.textContent.replace(/\s/g, "") === ""
+    const noText = !hasTextNode(elem)
 
     if (
       disabled ||

--- a/src/utils/__tests__/dom.js
+++ b/src/utils/__tests__/dom.js
@@ -153,3 +153,19 @@ describe("createStyleString", () => {
     expect(dom.createStyleString({})).toBe("")
   })
 })
+
+describe('hasTextNode', () => {
+  test('returns true when the element has a text node child', () => {
+    const elem = document.createElement("div")
+    elem.appendChild(document.createElement("span"))
+    elem.appendChild(document.createTextNode('text me'))
+    expect(dom.hasTextNode(elem)).toBe(true)
+  });
+
+  test('returns false when the element has no text node children', () => {
+    const elem = document.createElement("div")
+    elem.appendChild(document.createElement("span"))
+    elem.appendChild(document.createElement("span"))
+    expect(dom.hasTextNode(elem)).toBe(false)
+  })
+})

--- a/src/utils/__tests__/dom.js
+++ b/src/utils/__tests__/dom.js
@@ -154,15 +154,15 @@ describe("createStyleString", () => {
   })
 })
 
-describe('hasTextNode', () => {
-  test('returns true when the element has a text node child', () => {
+describe("hasTextNode", () => {
+  test("returns true when the element has a text node child", () => {
     const elem = document.createElement("div")
     elem.appendChild(document.createElement("span"))
-    elem.appendChild(document.createTextNode('text me'))
+    elem.appendChild(document.createTextNode("text me"))
     expect(dom.hasTextNode(elem)).toBe(true)
-  });
+  })
 
-  test('returns false when the element has no text node children', () => {
+  test("returns false when the element has no text node children", () => {
     const elem = document.createElement("div")
     elem.appendChild(document.createElement("span"))
     elem.appendChild(document.createElement("span"))

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -113,3 +113,8 @@ export function createStyleString(styleObj) {
   }
   return styleString
 }
+
+export function hasTextNode(elem) {
+  const nodes = Array.from(elem.childNodes)
+  return nodes.some(x => x.nodeType === Node.TEXT_NODE)
+}


### PR DESCRIPTION
closes CORE-1825

Test Plan:
  - Add something like:
    `<h2 style="color: #ffffff;"><span style="background: #000000;">[Course Title Here]</span></h2>`
    to the a11y checker tinymce instance
  - It should not be flagged as an issue when the a11y checker runs