### PR TITLE
Handle react 16’s async rendering

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,13 +11,23 @@ tinymce.create("tinymce.plugins.AccessibilityChecker", {
     const container = document.createElement("div")
     container.className = "tinymce-a11y-checker-container"
     document.body.appendChild(container)
-    instance = ReactDOM.render(
-      <Checker getBody={ed.getBody.bind(ed)} editor={ed} />,
-      container
-    )
-    pendingInstanceCallbacks.forEach(cb => cb(instance))
 
-    ed.addCommand("openAccessibilityChecker", instance.check.bind(instance))
+    ReactDOM.render(
+      <Checker getBody={ed.getBody.bind(ed)} editor={ed} />,
+      container,
+      function() {
+        // this is a workaround for react 16 since ReactDOM.render is not
+        // guaranteed to return the instance synchronously (especially if called
+        // within another component's lifecycle method eg: componentDidMount). see:
+        // https://github.com/facebook/react/issues/10309#issuecomment-318434635
+        instance = this
+        pendingInstanceCallbacks.forEach(cb => cb(instance))
+      }
+    )
+
+    ed.addCommand("openAccessibilityChecker", (...args) =>
+      instance.check(...args)
+    )
 
     ed.addButton("check_a11y", {
       title: formatMessage("Check Accessibility"),


### PR DESCRIPTION
this is a workaround for react 16 since ReactDOM.render is not 
guaranteed to return the instance synchronously (especially if called
within another component's lifecycle method eg: componentDidMount). see:
https://github.com/facebook/react/issues/10309#issuecomment-318434635

Test plan:
* when rendered into canvas-lms using react16, it shouldn’t throw errors