### PR TITLE
Add ids and linkText

### DIFF
--- a/src/components/__tests__/__snapshots__/checker.js.snap
+++ b/src/components/__tests__/__snapshots__/checker.js.snap
@@ -175,7 +175,9 @@ exports[`render matches snapshot with errors 1`] = `
                         size="medium"
                       >
                         <p>
-                          Why Text 
+                          Why Text
+                        </p>
+                        <p>
                           <Link
                             as="button"
                             ellipsis={false}
@@ -185,7 +187,7 @@ exports[`render matches snapshot with errors 1`] = `
                             target="_blank"
                             variant="default"
                           >
-                            Learn more
+                            Link for learning more
                           </Link>
                         </p>
                       </Text>

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -372,12 +372,12 @@ export default class Checker extends React.Component {
                                 {formatMessage("Close")}
                               </CloseButton>
                               <Text>
+                                <p>{rule.why()}</p>
                                 <p>
-                                  {rule.why() + " "}
                                   {rule.link &&
                                     rule.link.length && (
                                       <Link href={rule.link} target="_blank">
-                                        {formatMessage("Learn more")}
+                                        {rule.linkText()}
                                       </Link>
                                     )}
                                 </p>

--- a/src/rules/__mocks__/index.js
+++ b/src/rules/__mocks__/index.js
@@ -38,6 +38,7 @@ export default [
     update: jest.fn(),
     message: jest.fn().mockReturnValue("Error Message"),
     why: jest.fn().mockReturnValue("Why Text"),
-    link: "http://some-url"
+    link: "http://some-url",
+    linkText: jest.fn().mockReturnValue("Link for learning more")
   }
 ]

--- a/src/rules/__tests__/__snapshots__/adjacent-links.js.snap
+++ b/src/rules/__tests__/__snapshots__/adjacent-links.js.snap
@@ -16,6 +16,8 @@ Array [
 ]
 `;
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about adjacent links"`;
+
 exports[`message returns the proper message 1`] = `"Adjacent links with the same URL should be a single link."`;
 
 exports[`why returns the proper why message 1`] = `"Keyboards navigate to links using the Tab key. Two adjacent links that direct to the same destination can be confusing to keyboard users."`;

--- a/src/rules/__tests__/__snapshots__/headings-sequence.js.snap
+++ b/src/rules/__tests__/__snapshots__/headings-sequence.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about organizing page headings"`;
+
 exports[`message returns the proper message 1`] = `"Heading levels should not be skipped."`;
 
 exports[`why returns the proper why message 1`] = `"Sighted users browse web pages quickly, looking for large or bolded headings. Screen reader users rely on headers for contextual understanding. Headers should use the proper structure."`;

--- a/src/rules/__tests__/__snapshots__/img-alt-filename.js.snap
+++ b/src/rules/__tests__/__snapshots__/img-alt-filename.js.snap
@@ -9,6 +9,8 @@ Array [
 ]
 `;
 
+exports[`linkText returns the proper why message 1`] = `"Learn more about using filenames as alt text"`;
+
 exports[`message returns the proper message 1`] = `"Image filenames should not be used as the alt attribute describing the image content."`;
 
 exports[`why returns the proper why message 1`] = `"Screen readers cannot determine what is displayed in an image without alternative text, and filenames are often meaningless strings of numbers and letters that do not describe the context or meaning."`;

--- a/src/rules/__tests__/__snapshots__/img-alt.js.snap
+++ b/src/rules/__tests__/__snapshots__/img-alt.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about using alt text for images"`;
+
 exports[`message returns the proper message 1`] = `"Images should include an alt attribute describing the image content."`;
 
 exports[`why returns the proper why message 1`] = `"Screen readers cannot determine what is displayed in an image without alternative text, which describes the content and meaning of the image."`;

--- a/src/rules/__tests__/__snapshots__/large-text-contrast.js.snap
+++ b/src/rules/__tests__/__snapshots__/large-text-contrast.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about color contrast"`;
+
 exports[`message returns the proper message 1`] = `"Text larger than 18pt (or bold 14pt) should display a minimum contrast ratio of 3:1."`;
 
 exports[`why returns the proper why message 1`] = `"Text is difficult to read without sufficient contrast between the text and the background, especially for those with low vision."`;

--- a/src/rules/__tests__/__snapshots__/list-structure.js.snap
+++ b/src/rules/__tests__/__snapshots__/list-structure.js.snap
@@ -17,6 +17,8 @@ Array [
 ]
 `;
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about using lists"`;
+
 exports[`message returns the proper message 1`] = `"Lists should be formatted as lists."`;
 
 exports[`why returns the proper why message 1`] = `"When markup is used that visually formats items as a list but does not indicate the list relationship, users may have difficulty in navigating the information."`;

--- a/src/rules/__tests__/__snapshots__/small-text-contrast.js.snap
+++ b/src/rules/__tests__/__snapshots__/small-text-contrast.js.snap
@@ -10,6 +10,8 @@ Array [
 ]
 `;
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about color contrast"`;
+
 exports[`message returns the proper message 1`] = `"Text smaller than 18pt (or bold 14pt) should display a minimum contrast ratio of 4.5:1."`;
 
 exports[`why returns the proper why message 1`] = `"Text is difficult to read without sufficient contrast between the text and the background, especially for those with low vision."`;

--- a/src/rules/__tests__/__snapshots__/table-caption.js.snap
+++ b/src/rules/__tests__/__snapshots__/table-caption.js.snap
@@ -15,6 +15,8 @@ Array [
 ]
 `;
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about using captions with tables"`;
+
 exports[`message returns the proper message 1`] = `"Tables should include a caption describing the contents of the table."`;
 
 exports[`why returns the proper why message 1`] = `"Screen readers cannot interpret tables without the proper structure. Table captions describe the context and general understanding of the table."`;

--- a/src/rules/__tests__/__snapshots__/table-header-scope.js.snap
+++ b/src/rules/__tests__/__snapshots__/table-header-scope.js.snap
@@ -31,6 +31,8 @@ Array [
 ]
 `;
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about using scope attributes with tables"`;
+
 exports[`message returns the proper message 1`] = `"Tables headers should specify scope."`;
 
 exports[`why returns the proper message 1`] = `"Screen readers cannot interpret tables without the proper structure. Table headers provide direction and content scope."`;

--- a/src/rules/__tests__/__snapshots__/table-header.js.snap
+++ b/src/rules/__tests__/__snapshots__/table-header.js.snap
@@ -33,6 +33,8 @@ Array [
 ]
 `;
 
+exports[`linkText returns the proper linkText message 1`] = `"Learn more about table headers"`;
+
 exports[`message returns the proper message 1`] = `"Tables should include at least one header."`;
 
 exports[`update header option === both adds a header row and a header column 1`] = `

--- a/src/rules/__tests__/adjacent-links.js
+++ b/src/rules/__tests__/adjacent-links.js
@@ -184,3 +184,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/headings-sequence.js
+++ b/src/rules/__tests__/headings-sequence.js
@@ -80,3 +80,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/img-alt-filename.js
+++ b/src/rules/__tests__/img-alt-filename.js
@@ -169,3 +169,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper why message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/img-alt.js
+++ b/src/rules/__tests__/img-alt.js
@@ -109,3 +109,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/index.js
+++ b/src/rules/__tests__/index.js
@@ -1,0 +1,22 @@
+import rules from "../index"
+
+const ruleMap = rules.map(rule => [rule.id, rule])
+
+test.each(ruleMap)(
+  "%s should have a linkText function if it has a link",
+  (ruleId, rule) => {
+    if (rule.link && rule.link.length) {
+      expect(rule.linkText).toBeInstanceOf(Function)
+    }
+  }
+)
+
+test("all rules should have an id property", () => {
+  expect(ruleMap.every(x => x[0])).toBeTruthy()
+})
+
+test("all rules should have unique id properties", () => {
+  const ruleSet = new Set()
+  ruleMap.forEach(x => ruleSet.add(x[0]))
+  expect(ruleSet.size).toBe(ruleMap.length)
+})

--- a/src/rules/__tests__/large-text-contrast.js
+++ b/src/rules/__tests__/large-text-contrast.js
@@ -67,3 +67,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/list-structure.js
+++ b/src/rules/__tests__/list-structure.js
@@ -259,3 +259,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/small-text-contrast.js
+++ b/src/rules/__tests__/small-text-contrast.js
@@ -101,3 +101,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/table-caption.js
+++ b/src/rules/__tests__/table-caption.js
@@ -73,3 +73,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/table-header-scope.js
+++ b/src/rules/__tests__/table-header-scope.js
@@ -78,3 +78,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/__tests__/table-header.js
+++ b/src/rules/__tests__/table-header.js
@@ -94,3 +94,9 @@ describe("why", () => {
     expect(rule.why()).toMatchSnapshot()
   })
 })
+
+describe("linkText", () => {
+  test("returns the proper linkText message", () => {
+    expect(rule.linkText()).toMatchSnapshot()
+  })
+})

--- a/src/rules/adjacent-links.js
+++ b/src/rules/adjacent-links.js
@@ -63,6 +63,7 @@ const descendantImageWithRedundantAltText = (left, right) => {
 }
 
 export default {
+  id: "adjacent-links",
   test: function(elem) {
     if (elem.tagName != "A") {
       return true
@@ -114,5 +115,6 @@ export default {
       "Keyboards navigate to links using the Tab key. Two adjacent links that direct to the same destination can be confusing to keyboard users."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/H2.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/H2.html",
+  linkText: () => formatMessage("Learn more about adjacent links")
 }

--- a/src/rules/headings-sequence.js
+++ b/src/rules/headings-sequence.js
@@ -107,6 +107,7 @@ const getValidHeadings = elem => {
 }
 
 export default {
+  id: "headings-sequence",
   test: elem => {
     const testTags = {
       H2: true,
@@ -167,5 +168,6 @@ export default {
       "Sighted users browse web pages quickly, looking for large or bolded headings. Screen reader users rely on headers for contextual understanding. Headers should use the proper structure."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/G141.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/G141.html",
+  linkText: () => formatMessage("Learn more about organizing page headings")
 }

--- a/src/rules/img-alt-filename.js
+++ b/src/rules/img-alt-filename.js
@@ -4,6 +4,7 @@ import { filename } from "../utils/strings"
 import axios from "axios"
 
 export default {
+  id: "img-alt-filename",
   test: elem => {
     if (elem.tagName !== "IMG") {
       return true
@@ -59,5 +60,6 @@ export default {
       "Screen readers cannot determine what is displayed in an image without alternative text, and filenames are often meaningless strings of numbers and letters that do not describe the context or meaning."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/F30.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/F30.html",
+  linkText: () => formatMessage("Learn more about using filenames as alt text")
 }

--- a/src/rules/img-alt-length.js
+++ b/src/rules/img-alt-length.js
@@ -4,7 +4,7 @@ const MAX_ALT_LENGTH = 120
 
 export default {
   "max-alt-length": MAX_ALT_LENGTH,
-
+  id: "img-alt-length",
   test: elem => {
     if (elem.tagName !== "IMG") {
       return true

--- a/src/rules/img-alt.js
+++ b/src/rules/img-alt.js
@@ -1,6 +1,7 @@
 import formatMessage from "../format-message"
 
 export default {
+  id: "img-alt",
   test: elem => {
     if (elem.tagName !== "IMG") {
       return true
@@ -54,5 +55,6 @@ export default {
       "Screen readers cannot determine what is displayed in an image without alternative text, which describes the content and meaning of the image."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/H37.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/H37.html",
+  linkText: () => formatMessage("Learn more about using alt text for images")
 }

--- a/src/rules/large-text-contrast.js
+++ b/src/rules/large-text-contrast.js
@@ -4,6 +4,7 @@ import smallTextContrast from "./small-text-contrast"
 import { onlyContainsLink, hasTextNode } from "../utils/dom"
 
 export default {
+  id: "large-text-contrast",
   test: (elem, config = {}) => {
     const disabled = config.disableContrastCheck == true
     const noText = !hasTextNode(elem)
@@ -34,5 +35,6 @@ export default {
       "Text is difficult to read without sufficient contrast between the text and the background, especially for those with low vision."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/G17.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/G17.html",
+  linkText: () => formatMessage("Learn more about color contrast")
 }

--- a/src/rules/list-structure.js
+++ b/src/rules/list-structure.js
@@ -65,6 +65,7 @@ const splitParagraphsByBreak = paragraph => {
 }
 
 export default {
+  id: "list-structure",
   test: function(elem) {
     const isList = isTextList(elem)
     const isFirst = elem.previousElementSibling
@@ -147,5 +148,6 @@ export default {
       "When markup is used that visually formats items as a list but does not indicate the list relationship, users may have difficulty in navigating the information."
     ),
 
-  link: "https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/H48"
+  link: "https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/H48",
+  linkText: () => formatMessage("Learn more about using lists")
 }

--- a/src/rules/paragraphs-for-headings.js
+++ b/src/rules/paragraphs-for-headings.js
@@ -14,6 +14,7 @@ const IS_HEADING = {
 export default {
   "max-heading-length": MAX_HEADING_LENGTH,
 
+  id: "paragraphs-for-headings",
   test: elem => {
     if (!IS_HEADING[elem.tagName]) {
       return true

--- a/src/rules/small-text-contrast.js
+++ b/src/rules/small-text-contrast.js
@@ -9,6 +9,7 @@ import {
 import rgbHex from "../utils/rgb-hex"
 
 export default {
+  id: "small-text-contrast",
   test: (elem, config = {}) => {
     const disabled = config.disableContrastCheck == true
     const noText = !hasTextNode(elem)
@@ -63,5 +64,6 @@ export default {
       "Text is difficult to read without sufficient contrast between the text and the background, especially for those with low vision."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/G17.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/G17.html",
+  linkText: () => formatMessage("Learn more about color contrast")
 }

--- a/src/rules/table-caption.js
+++ b/src/rules/table-caption.js
@@ -2,6 +2,7 @@ import formatMessage from "../format-message"
 import { prepend } from "../utils/dom"
 
 export default {
+  id: "table-caption",
   test: elem => {
     if (elem.tagName !== "TABLE") {
       return true
@@ -43,5 +44,6 @@ export default {
       "Screen readers cannot interpret tables without the proper structure. Table captions describe the context and general understanding of the table."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/H39.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/H39.html",
+  linkText: () => formatMessage("Learn more about using captions with tables")
 }

--- a/src/rules/table-header-scope.js
+++ b/src/rules/table-header-scope.js
@@ -3,6 +3,7 @@ import formatMessage from "../format-message"
 const VALID_SCOPES = ["row", "col", "rowgroup", "colgroup"]
 
 export default {
+  id: "table-header-scope",
   test: elem => {
     if (elem.tagName !== "TH") {
       return true
@@ -46,5 +47,7 @@ export default {
       "Screen readers cannot interpret tables without the proper structure. Table headers provide direction and content scope."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/H63.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/H63.html",
+  linkText: () =>
+    formatMessage("Learn more about using scope attributes with tables")
 }

--- a/src/rules/table-header.js
+++ b/src/rules/table-header.js
@@ -4,6 +4,7 @@ import { changeTag } from "../utils/dom"
 const _forEach = Array.prototype.forEach
 
 export default {
+  id: "table-header",
   test: elem => {
     if (elem.tagName !== "TABLE") {
       return true
@@ -67,5 +68,6 @@ export default {
       "Screen readers cannot interpret tables without the proper structure. Table headers provide direction and overview of the content."
     ),
 
-  link: "https://www.w3.org/TR/WCAG20-TECHS/H43.html"
+  link: "https://www.w3.org/TR/WCAG20-TECHS/H43.html",
+  linkText: () => formatMessage("Learn more about table headers")
 }


### PR DESCRIPTION
This makes it so we can uniquely identify each rule within the
code.  It also provides a mechanism for saying more detailed
text for the "Learn more" links.

refs CORE-2115

Test Plan:
  - Open up the dev environment
  - Run the a11y checker
  - You should see errors show up.
  - Click the (?) hint button
  - The tooltip should contain a link for most rules
    that is descriptive (e.g, learn more about xyz)