### PR TITLE
Don't combine words when merging links (#11)

### DIFF
--- a/src/rules/__tests__/adjacent-links.js
+++ b/src/rules/__tests__/adjacent-links.js
@@ -54,12 +54,13 @@ describe("update", () => {
 
   test("returns A element with combined html content if 'combine' set", () => {
     const content = "this is my text"
+    const expected = `${content} ${content}`
     const text1 = document.createTextNode(content)
     a1.appendChild(text1)
     const text2 = document.createTextNode(content)
     a2.appendChild(text2)
     const newA = rule.update(a1, { combine: true })
-    expect(newA.textContent).toBe(content + content)
+    expect(newA.textContent).toBe(expected)
     expect(newA.tagName).toBe("A")
   })
 

--- a/src/rules/adjacent-links.js
+++ b/src/rules/adjacent-links.js
@@ -98,7 +98,7 @@ export default {
       }
 
       rootElem.removeChild(next)
-      elem.innerHTML += next.innerHTML
+      elem.innerHTML += ` ${next.innerHTML}`
     }
     return elem
   },


### PR DESCRIPTION
Adding some space between two combining adjacent link words...
