### PR TITLE
move focus to close button after applying a fix

### DIFF
--- a/src/components/__tests__/checker.js
+++ b/src/components/__tests__/checker.js
@@ -324,6 +324,12 @@ describe("fixIssue", () => {
     instance.fixIssue(ev)
     expect(instance.check).not.toHaveBeenCalled()
   })
+
+  test("focuses the close button", () => {
+    instance._closeButtonRef = {focus: jest.fn()}
+    instance.fixIssue(ev)
+    expect(instance._closeButtonRef.focus).toHaveBeenCalled()
+  })
 })
 
 describe("render", () => {

--- a/src/components/__tests__/checker.js
+++ b/src/components/__tests__/checker.js
@@ -326,7 +326,7 @@ describe("fixIssue", () => {
   })
 
   test("focuses the close button", () => {
-    instance._closeButtonRef = {focus: jest.fn()}
+    instance._closeButtonRef = { focus: jest.fn() }
     instance.fixIssue(ev)
     expect(instance._closeButtonRef.focus).toHaveBeenCalled()
   })

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -230,7 +230,7 @@ export default class Checker extends React.Component {
       rule.update(node, this.state.formState)
       this.updateErrorNode(node)
       if (this._closeButtonRef) {
-        this._closeButtonRef.focus();
+        this._closeButtonRef.focus()
       }
       const errorIndex = this.state.errorIndex
       this.check(() => this.setErrorIndex(errorIndex))

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -229,6 +229,9 @@ export default class Checker extends React.Component {
       this.removeTempNode()
       rule.update(node, this.state.formState)
       this.updateErrorNode(node)
+      if (this._closeButtonRef) {
+        this._closeButtonRef.focus();
+      }
       const errorIndex = this.state.errorIndex
       this.check(() => this.setErrorIndex(errorIndex))
     }
@@ -302,6 +305,7 @@ export default class Checker extends React.Component {
             placement="start"
             offset="x-small"
             onClick={() => this.handleClose()}
+            buttonRef={ref => (this._closeButtonRef = ref)}
           >
             {formatMessage("Close Accessibility Checker")}
           </CloseButton>


### PR DESCRIPTION
closes CORE-2847

test plan:
- open the demo
- open the a11y checker tray
- fix an issue
- focus should move back to the close button

Change-Id: I17e6263952c43dc48923f4914e613ac2091bb6b9