### PR TITLE
base img alt filename rule on regex pattern

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -65,6 +65,7 @@
           <p> - List item</p>
           <p>Split breaks:</p>
           <p>1. List Item<br>2. List Item</p>
+          <img src="http://placekitten.com/640/480" width="300" />
         </textarea>
     </div>
   </div>

--- a/src/rules/__tests__/img-alt-filename.js
+++ b/src/rules/__tests__/img-alt-filename.js
@@ -20,112 +20,12 @@ describe("test", () => {
 
   test("returns true if alt text is not filename", () => {
     el.setAttribute("alt", "some text")
-    return rule.test(el).then(result => expect(result).toBeTruthy())
+    expect(rule.test(el)).toBeTruthy()
   })
 
   test("returns false if alt text is filename", () => {
     el.setAttribute("alt", "file.txt")
-    return rule.test(el).then(result => expect(result).toBeFalsy())
-  })
-
-  describe("with redirects", () => {
-    beforeEach(() => {
-      moxios.install()
-    })
-
-    afterEach(() => {
-      moxios.uninstall()
-    })
-
-    test("returns true if alt text is not the filename after resolution of redirects with location header", done => {
-      el.setAttribute("alt", "some_img.jpg")
-      el.setAttribute("src", "/some_link_that_redirects")
-      const ruleResult = rule.test(el)
-      moxios.wait(() => {
-        const request = moxios.requests.mostRecent()
-        request
-          .respondWith({
-            status: 302,
-            headers: {
-              Location: "/not_some_img.jpg"
-            }
-          })
-          .then(() => {
-            ruleResult.then(response => {
-              expect(response).toBeTruthy()
-              done()
-            })
-          })
-      })
-    })
-
-    test("returns false if alt text is the filename after resolution of redirects with location header", done => {
-      el.setAttribute("alt", "some_img.jpg")
-      el.setAttribute("src", "/some_link_that_redirects")
-      const ruleResult = rule.test(el)
-      moxios.wait(() => {
-        const request = moxios.requests.mostRecent()
-        request
-          .respondWith({
-            status: 302,
-            headers: {
-              Location: "/some_img.jpg"
-            }
-          })
-          .then(() => {
-            ruleResult.then(response => {
-              expect(response).toBeFalsy()
-              done()
-            })
-          })
-      })
-    })
-
-    test("returns true if alt text is not the filename after resolution of redirects with content-disposition header", done => {
-      el.setAttribute("alt", "some_img.jpg")
-      el.setAttribute("src", "/some_link_that_redirects")
-      const ruleResult = rule.test(el)
-      moxios.wait(() => {
-        const request = moxios.requests.mostRecent()
-        request
-          .respondWith({
-            status: 302,
-            headers: {
-              Location: "/not_some_img",
-              "Content-Disposition": 'attachment; filename="not_some_img.jpg"'
-            }
-          })
-          .then(() => {
-            ruleResult.then(response => {
-              expect(response).toBeTruthy()
-              done()
-            })
-          })
-      })
-    })
-
-    test("returns false if alt text is the filename after resolution of redirects with content-disposition header", done => {
-      el.setAttribute("alt", "some_img.jpg")
-      el.setAttribute("src", "/some_link_that_redirects")
-      const ruleResult = rule.test(el)
-      moxios.wait(() => {
-        const request = moxios.requests.mostRecent()
-        request
-          .respondWith({
-            status: 302,
-            headers: {
-              Location: "/not_some_img",
-              "Content-Disposition": 'attachment; filename="some_img.jpg"'
-            }
-          })
-          .then(() => {
-            ruleResult.then(response => {
-              expect(response).toBeTruthy()
-              done()
-            })
-          })
-      })
-    })
+    expect(rule.test(el)).toBeFalsy()
   })
 })
 

--- a/src/rules/img-alt-filename.js
+++ b/src/rules/img-alt-filename.js
@@ -1,37 +1,13 @@
 import formatMessage from "../format-message"
-import { filename } from "../utils/strings"
 
 import axios from "axios"
 
+const FILENAMELIKE = /^\S+\.\S+$/
+
 export default {
   id: "img-alt-filename",
-  test: elem => {
-    if (elem.tagName !== "IMG") {
-      return true
-    }
-    const alt = elem.getAttribute("alt")
-    if (alt == null || alt === "") {
-      return true
-    }
-    return axios.head(elem.src).catch(e => {
-      if (
-        e.response &&
-        (e.response.status === 301 || e.response.status === 302)
-      ) {
-        const { location } = e.response.headers
-        const contentDisposition = e.response.headers["content-disposition"]
-        const matches = []
-        if (location) {
-          matches.push(filename(alt) !== filename(location))
-        }
-        if (contentDisposition) {
-          matches.push(filename(alt) !== filename(contentDisposition))
-        }
-        return matches.some(x => x)
-      }
-      return filename(alt) !== filename(elem.src)
-    })
-  },
+
+  test: elem => !FILENAMELIKE.test(elem.getAttribute("alt")),
 
   data: elem => {
     const alt = elem.getAttribute("alt")


### PR DESCRIPTION
closes CORE-1747

test plan:
- run the demo
- the img alt filename example should still fail
- it should be fixable by makeing it not a filename

Change-Id: I47a0cc3346936ce50ff66ef5e09364c929071412