### PR TITLE
Update Dockerfile to Node 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM instructure/node:8
+FROM instructure/node:10
 
 USER root
 RUN apt-get update \


### PR DESCRIPTION
The previous image for Node 8 was removed.

Test Plan:
  - Build dockerfile
  - Everything runs and works like normal