### PR TITLE
Improve focus managmenet

### DIFF
--- a/src/components/__tests__/__snapshots__/checker.js.snap
+++ b/src/components/__tests__/__snapshots__/checker.js.snap
@@ -5,6 +5,7 @@ exports[`render matches snapshot with errors 1`] = `
   <Tray
     border={false}
     contentRef={[Function]}
+    data-mce-component={true}
     defaultFocusElement={null}
     insertAt="bottom"
     label="Accessibility Checker"
@@ -452,6 +453,7 @@ exports[`render matches snapshot without errors 1`] = `
   <Tray
     border={false}
     contentRef={[Function]}
+    data-mce-component={true}
     defaultFocusElement={null}
     insertAt="bottom"
     label="Accessibility Checker"

--- a/src/components/__tests__/checker.js
+++ b/src/components/__tests__/checker.js
@@ -1,6 +1,6 @@
 import React from "react"
 import Checker from "../checker"
-import { shallow } from "enzyme"
+import { shallow, mount } from "enzyme"
 import util from "util"
 
 const promisify = util.promisify
@@ -32,7 +32,9 @@ beforeEach(() => {
   fakeEditor = {
     getContainer: () => ({
       querySelector: () => fakeIframe
-    })
+    }),
+    on: jest.fn(),
+    focus: jest.fn()
   }
   child = node.appendChild(document.createElement("div"))
   child2 = node.appendChild(document.createElement("div"))
@@ -74,9 +76,9 @@ describe("check", () => {
       test: async () => {
         return Promise.resolve(false)
       },
-      data: elem => {},
+      data: elem => { },
       form: () => [],
-      update: (elem, data) => {},
+      update: (elem, data) => { },
       message: () => "Async works!",
       why: () => "Because async",
       link: "http://isAsync"
@@ -166,7 +168,7 @@ describe("check", () => {
   })
 
   test("does nothing if props.getBody() returns falsy", () => {
-    component = shallow(<Checker getBody={() => false} />)
+    component = shallow(<Checker getBody={() => false} editor={fakeEditor} />)
     instance = component.instance()
     const spy = jest.fn()
     instance.check(spy)
@@ -182,6 +184,35 @@ describe("check", () => {
         instance.check("123")
         jest.runAllTimers()
       }).not.toThrow()
+    })
+  })
+
+  describe("close", () => {
+    beforeEach(() => jest.useFakeTimers())
+    afterEach(() => {
+      jest.useRealTimers()
+      jest.restoreAllMocks()
+      component.unmount()
+    })
+
+    it("calls editor.on('Remove') when mounted", () => {
+      component = mount(<Checker getBody={() => node} editor={fakeEditor} />)
+      instance = component.instance()
+      instance.check() // open it
+      jest.runAllTimers()
+      expect(fakeEditor.on).toHaveBeenCalled()
+      expect(fakeEditor.on.mock.calls[0][0]).toEqual("Remove")
+    })
+
+    it("calls focus on the editor on closing the tray", () => {
+      component = mount(<Checker getBody={() => node} editor={fakeEditor} foo={7} />)
+      instance = component.instance()
+      instance.check() // opens it
+      jest.runAllTimers()
+      const closeButton = document.querySelector('[data-mce-component] button')
+      closeButton.click()
+      jest.runAllTimers()
+      expect(instance.props.editor.focus).toHaveBeenCalled()
     })
   })
 })

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -33,7 +33,7 @@ import rules from "../rules"
 import formatMessage from "../format-message"
 import { clearIndicators } from "../utils/indicate"
 
-const noop = () => {}
+const noop = () => { }
 
 export default class Checker extends React.Component {
   state = {
@@ -49,6 +49,12 @@ export default class Checker extends React.Component {
 
   static defaultProps = {
     additionalRules: []
+  }
+
+  componentDidMount() {
+    this.props.editor.on('Remove', (editor) => {
+      this.setState({ open: false })
+    })
   }
 
   setConfig(config) {
@@ -285,6 +291,10 @@ export default class Checker extends React.Component {
     this.setState({ open: false })
   }
 
+  handleExited() {
+    this.props.editor.focus(false)
+  }
+
   render() {
     const rule = this.errorRule()
     const issueNumberMessage = formatMessage("Issue { num }/{ total }", {
@@ -295,9 +305,11 @@ export default class Checker extends React.Component {
     return (
       <LiveAnnouncer>
         <Tray
+          data-mce-component
           label={formatMessage("Accessibility Checker")}
           open={this.state.open}
           onDismiss={() => this.handleClose()}
+          onExited={() => this.handleExited()}
           placement="end"
           contentRef={e => (this.trayElement = e)}
         >


### PR DESCRIPTION
This makes three changes to help improve focus management
1. if the editor associated with an a11y checker is removed, close the checker
2. when the checker is closed, focus the associated editor
3. add the data-mce-checker attribute to the checker's Tray component.
   Consuming applications may use this to detect that even though focus
   may have left the editor, it is still within a compnent that can be
   considered a paart of the editor's ecosystem.