### PR TITLE
Force node version on travis to 12.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - 12.4
   - lts/*
 script:
   - npm run test:coverage


### PR DESCRIPTION
It seems that jest --coverage never exits when run
on node 12.5.0 so we'll pin to this working version for
now and re-evaluate in the future

Test Plan:
  - Tests pass