### PR TITLE
undo editor.focus() on closing the tray

### DIFF
--- a/src/components/__tests__/checker.js
+++ b/src/components/__tests__/checker.js
@@ -76,9 +76,9 @@ describe("check", () => {
       test: async () => {
         return Promise.resolve(false)
       },
-      data: elem => {},
+      data: elem => { },
       form: () => [],
-      update: (elem, data) => {},
+      update: (elem, data) => { },
       message: () => "Async works!",
       why: () => "Because async",
       link: "http://isAsync"
@@ -202,17 +202,6 @@ describe("check", () => {
       jest.runAllTimers()
       expect(fakeEditor.on).toHaveBeenCalled()
       expect(fakeEditor.on.mock.calls[0][0]).toEqual("Remove")
-    })
-
-    it("calls focus on the editor on closing the tray", () => {
-      component = mount(<Checker getBody={() => node} editor={fakeEditor} />)
-      instance = component.instance()
-      instance.check() // opens it
-      jest.runAllTimers()
-      const closeButton = document.querySelector("[data-mce-component] button")
-      closeButton.click()
-      jest.runAllTimers()
-      expect(instance.props.editor.focus).toHaveBeenCalled()
     })
   })
 })

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -33,7 +33,7 @@ import rules from "../rules"
 import formatMessage from "../format-message"
 import { clearIndicators } from "../utils/indicate"
 
-const noop = () => {}
+const noop = () => { }
 
 export default class Checker extends React.Component {
   state = {
@@ -291,10 +291,6 @@ export default class Checker extends React.Component {
     this.setState({ open: false })
   }
 
-  handleExited() {
-    this.props.editor.focus(false)
-  }
-
   render() {
     const rule = this.errorRule()
     const issueNumberMessage = formatMessage("Issue { num }/{ total }", {
@@ -309,7 +305,6 @@ export default class Checker extends React.Component {
           label={formatMessage("Accessibility Checker")}
           open={this.state.open}
           onDismiss={() => this.handleClose()}
-          onExited={() => this.handleExited()}
           placement="end"
           contentRef={e => (this.trayElement = e)}
         >


### PR DESCRIPTION
this turned out to be a bad idea is the client wants focus
to return to the button that was clicked to open the a11y checker
forcing this on users is not nice.