### PR TITLE
Do not automatically focus the editor on closing a11y checker

### DIFF
--- a/src/components/__tests__/checker.js
+++ b/src/components/__tests__/checker.js
@@ -203,17 +203,6 @@ describe("check", () => {
       expect(fakeEditor.on).toHaveBeenCalled()
       expect(fakeEditor.on.mock.calls[0][0]).toEqual("Remove")
     })
-
-    it("calls focus on the editor on closing the tray", () => {
-      component = mount(<Checker getBody={() => node} editor={fakeEditor} />)
-      instance = component.instance()
-      instance.check() // opens it
-      jest.runAllTimers()
-      const closeButton = document.querySelector("[data-mce-component] button")
-      closeButton.click()
-      jest.runAllTimers()
-      expect(instance.props.editor.focus).toHaveBeenCalled()
-    })
   })
 })
 

--- a/src/components/checker.js
+++ b/src/components/checker.js
@@ -291,10 +291,6 @@ export default class Checker extends React.Component {
     this.setState({ open: false })
   }
 
-  handleExited() {
-    this.props.editor.focus(false)
-  }
-
   render() {
     const rule = this.errorRule()
     const issueNumberMessage = formatMessage("Issue { num }/{ total }", {
@@ -309,7 +305,6 @@ export default class Checker extends React.Component {
           label={formatMessage("Accessibility Checker")}
           open={this.state.open}
           onDismiss={() => this.handleClose()}
-          onExited={() => this.handleExited()}
           placement="end"
           contentRef={e => (this.trayElement = e)}
         >


### PR DESCRIPTION
This seemed like a good idea at the time, but makes it impossible
to implement any other desired focus handling scheme (like returning
focus to the button that launched the a11y checker).