### PR TITLE
Modify pattern for filename to skip whitespaces

### DIFF
--- a/src/rules/__tests__/img-alt-filename.js
+++ b/src/rules/__tests__/img-alt-filename.js
@@ -31,6 +31,11 @@ describe("test", () => {
     el.setAttribute("alt", "file.txt")
     expect(rule.test(el)).toBeFalsy()
   })
+
+  test("returns false if alt text is filename with blank spaces", () => {
+    el.setAttribute("alt", "file with blank.txt")
+    expect(rule.test(el)).toBeFalsy()
+  })
 })
 
 describe("data", () => {

--- a/src/rules/img-alt-filename.js
+++ b/src/rules/img-alt-filename.js
@@ -1,6 +1,6 @@
 import formatMessage from "../format-message"
 
-const FILENAMELIKE = /^\S+\.\S+$/
+const FILENAMELIKE = /^(\S|\s)+\.\S+$/
 
 export default {
   id: "img-alt-filename",


### PR DESCRIPTION
fixes MAT-464
flag=none

Test plan:
- Navigate to an RCE instance
- Upload an image (jpg, png mainly) and assign an alt attribute
as a filename with spaces (i.e this image.jpg)
- After upload and preview, click the accesibility checker.
It must warn of a filename not allowed as an alt attribute
- repeat the process with a different alt value, this time
use a normal sentence. Click the accesibility checker again.
this time there must be no alerts or messages