### PR TITLE
Version Bump 3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce-a11y-checker",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "An accessibility checker plugin for TinyMCE.",
   "main": "lib/plugin.js",
   "module": "lib/modules/plugin.js",

--- a/src/rules/__tests__/list-structure.js
+++ b/src/rules/__tests__/list-structure.js
@@ -35,6 +35,15 @@ describe("test", () => {
     expect(rule.test(p2)).toBeFalsy()
   })
 
+  test("returns true if ol-like but item label is more than 4 chars", () => {
+    p1.textContent = "12345. list like"
+    p2.textContent = "ABCDE. list like"
+    p3.textContent = "abcde) list like"
+    expect(rule.test(p1)).toBeTruthy()
+    expect(rule.test(p2)).toBeTruthy()
+    expect(rule.test(p3)).toBeTruthy()
+  })
+
   test("returns true if li-like", () => {
     p2.textContent = " * List"
     p3.textContent = " * List"

--- a/src/rules/__tests__/list-structure.js
+++ b/src/rules/__tests__/list-structure.js
@@ -44,7 +44,7 @@ describe("test", () => {
     expect(rule.test(p3)).toBeTruthy()
   })
 
-  test("returns true if li-like", () => {
+  test("returns false if li-like", () => {
     p2.textContent = " * List"
     p3.textContent = " * List"
     expect(rule.test(p2)).toBeFalsy()

--- a/src/rules/list-structure.js
+++ b/src/rules/list-structure.js
@@ -10,7 +10,7 @@ import formatMessage from "../format-message"
  * a. list Item
  */
 
-const orderedChars = `[A-Z]+|[a-z]+|[0-9]+`
+const orderedChars = ["[A-Z]", "[a-z]", "[0-9]"].map(pattern => pattern + "{1,4}").join("|")
 const bulletMarkers = ["*", "-"].map(c => "\\" + c).join("|")
 const orderedMarkers = [".", ")"].map(c => "\\" + c).join("|")
 
@@ -66,7 +66,7 @@ const splitParagraphsByBreak = paragraph => {
 
 export default {
   id: "list-structure",
-  test: function(elem) {
+  test: function (elem) {
     const isList = isTextList(elem)
     const isFirst = elem.previousElementSibling
       ? !isTextList(elem.previousElementSibling)
@@ -91,7 +91,7 @@ export default {
     }
   ],
 
-  update: function(elem, data) {
+  update: function (elem, data) {
     const rootElem = elem.parentNode
 
     if (data.formatAsList) {
@@ -137,7 +137,7 @@ export default {
     return elem
   },
 
-  rootNode: function(elem) {
+  rootNode: function (elem) {
     return elem.parentNode
   },
 


### PR DESCRIPTION
stop flagging arbitrary length text at the beginning of a paragraph followed by a period or closing parenthesis as a rule
violation; limit flags to items of four characters or less

fixes MAT-531
flag=none

test plan:
- open up the RCE
- type 5 characters of the same class (lowercase, uppercase, or digits) followed by a period or closing parenthesis, a space, and then arbitrary text
- observe this is not flagged by the a11y checker
- remove one of the 5 initial characters
- observe this is now flagged by the a11y checker