### PR TITLE
Fix bug in locating the a11y violation indictor box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.3]
+
+- fix function that moves the box highlighting a11y violations so it properly tracks
+  when the user scrolls
+
 ## [4.1.2] - 2022-11-30
 
 - Changes to cope with the RCE being put in browser-native fullscreen

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "tinymce-a11y-checker",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "An accessibility checker plugin for TinyMCE.",
+  "repository": "https://github.com/instructure/tinymce-a11y-checker",
   "main": "lib/plugin.js",
   "module": "es/plugin.js",
   "scripts": {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -32,7 +32,7 @@ export function select(editor, elem, indicateFn = indicate) {
   if (elem == null) {
     return
   }
-  elem.scrollIntoView()
+  elem.scrollIntoView(false)
   indicateFn(editor, elem)
 }
 
@@ -106,7 +106,7 @@ export function splitStyleAttribute(styleString) {
 
 export function createStyleString(styleObj) {
   let styleString = Object.keys(styleObj)
-    .map(key => `${key}:${styleObj[key]}`)
+    .map((key) => `${key}:${styleObj[key]}`)
     .join(";")
   if (styleString) {
     styleString = `${styleString};`
@@ -116,5 +116,5 @@ export function createStyleString(styleObj) {
 
 export function hasTextNode(elem) {
   const nodes = Array.from(elem.childNodes)
-  return nodes.some(x => x.nodeType === Node.TEXT_NODE)
+  return nodes.some((x) => x.nodeType === Node.TEXT_NODE)
 }


### PR DESCRIPTION
the function that moved the box as the page or tinymce content area scrolled didn't call requestAnimationFrame correctly

bumped version number

closes MAT-1134