### PR TITLE
Mat 1134b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.3]
+
+- fix function that moves the box highlighting a11y violations so it properly tracks
+  when the user scrolls
+
 ## [4.1.2] - 2022-11-30
 
 - Changes to cope with the RCE being put in browser-native fullscreen

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "tinymce-a11y-checker",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "An accessibility checker plugin for TinyMCE.",
+  "repository": "https://github.com/instructure/tinymce-a11y-checker",
   "main": "lib/plugin.js",
   "module": "es/plugin.js",
   "scripts": {

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -32,7 +32,7 @@ export function select(editor, elem, indicateFn = indicate) {
   if (elem == null) {
     return
   }
-  elem.scrollIntoView()
+  elem.scrollIntoView(false)
   indicateFn(editor, elem)
 }
 
@@ -106,7 +106,7 @@ export function splitStyleAttribute(styleString) {
 
 export function createStyleString(styleObj) {
   let styleString = Object.keys(styleObj)
-    .map(key => `${key}:${styleObj[key]}`)
+    .map((key) => `${key}:${styleObj[key]}`)
     .join(";")
   if (styleString) {
     styleString = `${styleString};`
@@ -116,5 +116,5 @@ export function createStyleString(styleObj) {
 
 export function hasTextNode(elem) {
   const nodes = Array.from(elem.childNodes)
-  return nodes.some(x => x.nodeType === Node.TEXT_NODE)
+  return nodes.some((x) => x.nodeType === Node.TEXT_NODE)
 }

--- a/src/utils/indicate.js
+++ b/src/utils/indicate.js
@@ -115,7 +115,9 @@ export default function indicate(editor, elem, padding = PADDING) {
       ) {
         // the page is scrolled so the indicator should be behind tinymce's sticky header
         const newHeight =
-          region.height - (stickyOffset - (region.top + bodyRect.top))
+          region.height -
+          (stickyOffset - (region.top + bodyRect.top)) -
+          padPlusBorder
         if (newHeight < 0) {
           el.style.display = "none"
         }
@@ -123,7 +125,7 @@ export default function indicate(editor, elem, padding = PADDING) {
         el.style.height = `${newHeight}px`
       } else if (boundingRect.top - padPlusBorder < 0) {
         // tinymce's iframe content is scrolled so the indicator is above the visible area
-        const newHeight = region.height + boundingRect.top
+        const newHeight = region.height + boundingRect.top - padPlusBorder
         if (newHeight < 0) {
           el.style.display = "none"
         }
@@ -135,7 +137,9 @@ export default function indicate(editor, elem, padding = PADDING) {
       ) {
         // the indicator is below the visible area in tinymce's content area
         const newHeight =
-          region.height - (boundingRect.bottom - editorFrameOffset.height)
+          region.height -
+          (boundingRect.bottom - editorFrameOffset.height) -
+          padPlusBorder
         if (newHeight < 0) {
           el.style.display = "none"
         }


### PR DESCRIPTION
- the function that moved the box as the page or tinymce content area scrolled didn't call requestAnimationFrame correctly
- the code that located the box as the the violation scrolled out of view wasn't located correctly
- when the a11y checker opened it would call violationelement.scrollIntoView(), which could be hidden behind tinymce's sticky header if the RCE was scrolled to the top of the page
- bumped version number

closes MAT-1134