### PR TITLE
Update README to indicte this repo is no longer being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # TinyMCE Accessibility Checker Plugin _(tinymce-a11y-checker)_
 
+## Deprecated
+
+This package had been merged into `@instructure/canvas-rce`. This repository
+is no longer under development or being maintained.
+
+The corresponding npm package has been deprecated.
+
+If you use the Rich Content Editor from Canvas, the a11y checker is now
+built in.
+
+---
+
 > An accessibility checker plugin for TinyMCE.
 
 [![Build Status](https://travis-ci.com/instructure/tinymce-a11y-checker.svg?branch=master)](https://travis-ci.com/instructure/tinymce-a11y-checker)
 [![npm](https://img.shields.io/npm/v/tinymce-a11y-checker.svg)](https://www.npmjs.com/package/tinymce-a11y-checker)
-
 
 ## Install
 
@@ -27,7 +38,7 @@ import "tinymce-a11y-checker"
 tinymce.init({
   selector: "#editor",
   plugins: ["a11y_checker"],
-  toolbar: "check_a11y | bold italic ..."
+  toolbar: "check_a11y | bold italic ...",
 })
 ```
 


### PR DESCRIPTION
The tinymce-a11y-checker is not built into the `@instructure/canvas-rce`